### PR TITLE
0.2.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumo"
-version = "0.2.4"
+version = "0.2.5"
 description = "CPU based rendering engine"
 license = "MIT"
 repository = "https://github.com/ekarpp/lumo"

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ fn main() -> Result<(), png::EncodingError> {
 ### Gallery
 ![Stanford dragon](https://i.imgur.com/4Wj2Fgy.png)
 ![Cornell box](https://i.imgur.com/PoEVv6b.png)
-![Circle of spheres](https://i.imgur.com/JxvP1l7.png)
+![Circle of spheres](https://i.imgur.com/GJXdijq.png)

--- a/src/efloat.rs
+++ b/src/efloat.rs
@@ -1,0 +1,172 @@
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+/// Makes the smallest increment possible to `v`
+fn _next_double(v: f64) -> f64 {
+    if v.is_infinite() && v > 0.0 {
+        v
+    } else {
+        let v = if v == -0.0 { 0.0 } else { v };
+        let bits = if v >= 0.0 {
+            v.to_bits() + 1
+        } else {
+            v.to_bits() - 1
+        };
+        f64::from_bits(bits)
+    }
+}
+
+/// Makes the smalles decrement possible to `v`
+fn _previous_double(v: f64) -> f64 {
+    if v.is_infinite() && v < 0.0 {
+        v
+    } else {
+        let v = if v == 0.0 { -0.0 } else { v };
+        let bits = if v > 0.0 {
+            v.to_bits() - 1
+        } else {
+            v.to_bits() + 1
+        };
+        f64::from_bits(bits)
+    }
+}
+
+/// `f64` with running floating point error tracking
+pub struct EFloat64 {
+    /// Actual `f64` value
+    value: f64,
+    /// Lower bound of error interval
+    low: f64,
+    /// Higher bound of error interval
+    high: f64,
+}
+
+impl EFloat64 {
+    fn new(value: f64, low: f64, high: f64) -> Self {
+        Self {
+            value,
+            low,
+            high,
+        }
+    }
+
+    pub fn sqrt(self) -> Self {
+        Self::new(
+            self.value.sqrt(),
+            _previous_double(self.low.sqrt()),
+            _next_double(self.high.sqrt()),
+        )
+    }
+}
+
+impl From<f64> for EFloat64 {
+    fn from(value: f64) -> Self {
+        Self::new(
+            value,
+            value,
+            value,
+        )
+    }
+}
+
+impl Neg for EFloat64 {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Self::new(
+            -self.value,
+            -self.low,
+            -self.high,
+        )
+    }
+}
+
+impl Add for EFloat64 {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self::new(
+            self.value + other.value,
+            _previous_double(self.low + other.low),
+            _next_double(self.high + other.high),
+        )
+    }
+}
+
+impl Sub for EFloat64 {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        Self::new(
+            self.value - other.value,
+            _previous_double(self.low - other.high),
+            _next_double(self.high - other.low),
+        )
+    }
+}
+
+impl Mul for EFloat64 {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        let prod_bounds = [
+            self.low * other.low,
+            self.low * other.high,
+            self.high * other.low,
+            self.high * other.high,
+        ];
+
+        let min = prod_bounds[0]
+            .min(prod_bounds[1])
+            .min(prod_bounds[2])
+            .min(prod_bounds[3]);
+
+        let max = prod_bounds[0]
+            .max(prod_bounds[1])
+            .max(prod_bounds[2])
+            .max(prod_bounds[3]);
+
+        Self::new(
+            self.value * other.value,
+            _previous_double(min),
+            _next_double(max),
+        )
+    }
+}
+
+impl Div for EFloat64 {
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        if other.low < 0.0 && other.high > 0.0 {
+            // possible division by zero. just make interval everything..
+            Self::new(
+                self.value / other.value,
+                f64::NEG_INFINITY,
+                f64::INFINITY,
+            )
+        } else {
+            let div_bounds = [
+                self.low / other.low,
+                self.low / other.high,
+                self.high / other.low,
+                self.high / other.high,
+            ];
+
+            let min = div_bounds[0]
+                .min(div_bounds[1])
+                .min(div_bounds[2])
+                .min(div_bounds[3]);
+
+            let max = div_bounds[0]
+                .max(div_bounds[1])
+                .max(div_bounds[2])
+                .max(div_bounds[3]);
+
+            Self::new(
+                self.value / other.value,
+                _previous_double(min),
+                _next_double(max),
+            )
+        }
+    }
+}

--- a/src/efloat.rs
+++ b/src/efloat.rs
@@ -49,6 +49,7 @@ impl EFloat64 {
         }
     }
 
+    #[allow(dead_code)]
     pub fn sqrt(self) -> Self {
         Self::new(
             self.value.sqrt(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,6 @@ use glam::DVec3;
 /// Epsilon to avoid self intersection of objects
 const EPSILON: f64 = 1e-10;
 
-/// Epsilon of how much we move ray back when evaluating it at point `t`
-const EPSILON_RAY_OFFSET: f64 = 1e-14;
-
 pub use cli::TracerCli;
 pub use image::Image;
 pub use perlin::Perlin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod tracer;
 
 /// Command line interface
 mod cli;
+/// `f64` with built in tracking of floating point error
+mod efloat;
 /// Wrapper for writing image buffer to file.
 mod image;
 /// Perlin noise generator.
@@ -29,7 +31,6 @@ mod rand_utils;
 mod renderer;
 /// Different iterators that stream values sampled from the unit square.
 mod samplers;
-
 /// Tone mapping functions
 mod tone_mapping;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ use glam::DVec3;
 /// Epsilon to avoid self intersection of objects
 const EPSILON: f64 = 1e-10;
 
+/// Epsilon of how much we move ray back when evaluating it at point `t`
+const EPSILON_RAY_OFFSET: f64 = 1e-14;
+
 pub use cli::TracerCli;
 pub use image::Image;
 pub use perlin::Perlin;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -108,9 +108,10 @@ impl Renderer {
                 // random offsets
                 let ou = rand_sq.x / max_dim;
                 let ov = rand_sq.y / max_dim;
-                let rgb = self
-                    .integrator
-                    .integrate(&self.scene, self.camera.ray_at(u + ou, v + ov));
+                let rgb = self.integrator.integrate(
+                    &self.scene,
+                    self.camera.generate_ray(u + ou, v + ov)
+                );
 
                 self.tone_map.map(rgb)
             })

--- a/src/tracer/bxdfs.rs
+++ b/src/tracer/bxdfs.rs
@@ -103,18 +103,16 @@ pub fn bsdf_microfacet_pdf(
     mfd: &MfDistribution,
 ) -> Option<Box<dyn Pdf>> {
     let ng = ho.ng;
-    let xo = ho.p;
     let v = -ro.dir;
-    Some( Box::new(MfdPdf::new(xo, v, ng, albedo, *mfd)) )
+    Some( Box::new(MfdPdf::new(v, ng, albedo, *mfd)) )
 }
 
 /// Scattering function for mirror material. Perfect reflection.
 pub fn brdf_mirror_pdf(ho: &Hit, ro: &Ray) -> Option<Box<dyn Pdf>> {
-    let xo = ho.p;
     let wo = ro.dir;
     let no = ho.ng;
     let wi = reflect(-wo, no);
-    Some(Box::new(DeltaPdf::new(xo, wi)))
+    Some( Box::new(DeltaPdf::new(wi)) )
 }
 
 pub fn btdf_glass_pdf(ho: &Hit, ro: &Ray, rfrct_idx: f64) -> Option<Box<dyn Pdf>> {
@@ -123,14 +121,13 @@ pub fn btdf_glass_pdf(ho: &Hit, ro: &Ray, rfrct_idx: f64) -> Option<Box<dyn Pdf>
     let inside = ng.dot(v) < 0.0;
     let eta_ratio = if inside { rfrct_idx } else { 1.0 / rfrct_idx };
     let ng = if inside { -ng } else { ng };
-    let xo = ho.p;
 
     let wi = match refract(eta_ratio, v, ng) {
         None => reflect(v, ng),
         Some(wi) => wi,
     };
 
-    Some( Box::new(DeltaPdf::new(xo, wi)) )
+    Some( Box::new(DeltaPdf::new(wi)) )
 }
 
 /// Reflect around normal

--- a/src/tracer/camera.rs
+++ b/src/tracer/camera.rs
@@ -32,7 +32,7 @@ impl Camera {
     /// # Arguments
     /// * `x` - x coordinate in a \[-1,1\]^2 square
     /// * `y` - y coordinate in a \[-1,1\]^2 square
-    pub fn ray_at(&self, x: f64, y: f64) -> Ray {
+    pub fn generate_ray(&self, x: f64, y: f64) -> Ray {
         Ray::new(self.origin, self.forward + x * self.right + y * self.up)
     }
 

--- a/src/tracer/hit.rs
+++ b/src/tracer/hit.rs
@@ -1,4 +1,5 @@
 use crate::tracer::object::Object;
+use crate::tracer::ray::Ray;
 use glam::DVec3;
 
 /// Stores information about a hit between a ray and an object.
@@ -37,5 +38,13 @@ impl<'a> Hit<'a> {
             ns,
             ng,
         })
+    }
+
+    /// Generates a ray at point of impact. TODO: fix origin for fp inaccuracies.
+    pub fn generate_ray(&self, wi: DVec3) -> Ray {
+        Ray::new(
+            self.p,
+            wi
+        )
     }
 }

--- a/src/tracer/hit.rs
+++ b/src/tracer/hit.rs
@@ -1,3 +1,4 @@
+use crate::EPSILON;
 use crate::tracer::object::Object;
 use crate::tracer::ray::Ray;
 use glam::DVec3;
@@ -40,10 +41,14 @@ impl<'a> Hit<'a> {
         })
     }
 
-    /// Generates a ray at point of impact. TODO: fix origin for fp inaccuracies.
+    /// Generates a ray at point of impact. Would be better to use accurate
+    /// error bounds instead of `EPSILON`.
     pub fn generate_ray(&self, wi: DVec3) -> Ray {
+        let norm = if wi.dot(self.ng) >= 0.0 { self.ng } else { -self.ng };
+        let xi = self.p + norm * EPSILON;
+
         Ray::new(
-            self.p,
+            xi,
             wi
         )
     }

--- a/src/tracer/integrator/direct_light.rs
+++ b/src/tracer/integrator/direct_light.rs
@@ -11,9 +11,10 @@ pub fn integrate(scene: &Scene, ro: Ray) -> DVec3 {
                 None => material.emit(&ho),
                 Some(scatter_pdf) => {
                     if material.is_specular() {
-                        match scatter_pdf.sample_ray(rand_utils::unit_square()) {
+                        match scatter_pdf.sample_direction(rand_utils::unit_square()) {
                             None => DVec3::ZERO,
-                            Some(ri) => {
+                            Some(wi) => {
+                                let ri = ho.generate_ray(wi);
                                 let wi = ri.dir;
 
                                 let p_scatter = scatter_pdf.value_for(&ri);

--- a/src/tracer/integrator/path_trace.rs
+++ b/src/tracer/integrator/path_trace.rs
@@ -36,11 +36,12 @@ pub fn integrate(scene: &Scene, mut ro: Ray) -> DVec3 {
 
                 illuminance += gathered * shadow;
 
-                match scatter_pdf.sample_ray(rand_utils::unit_square()) {
+                match scatter_pdf.sample_direction(rand_utils::unit_square()) {
                     None => {
                         break;
                     }
-                    Some(ri) => {
+                    Some(wi) => {
+                        let ri = ho.generate_ray(wi);
                         let wi = ri.dir;
                         let p_scatter = scatter_pdf.value_for(&ri);
 

--- a/src/tracer/object.rs
+++ b/src/tracer/object.rs
@@ -65,13 +65,13 @@ pub trait Sampleable: Object {
     /// Sample random point on the surface of the object
     fn sample_on(&self, rand_sq: DVec2) -> DVec3;
 
-    /// Sample random ray from `xo` towards area of object
+    /// Sample random direction from `xo` towards area of object
     /// that is visible form `xo`
     ///
     /// # Arguments
     /// * `xo` - Point on the "from" object
     /// * `rand_sq` - Uniformly random point on unit square
-    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> Ray;
+    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> DVec3;
 
     /// PDF for sampling points on the surface uniformly at random. Returns PDF
     /// with respect to area and hit to self, if found.

--- a/src/tracer/object/cube.rs
+++ b/src/tracer/object/cube.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(test)]
+mod cube_tests;
+
 /// A cube consisting of 6 rectangles
 pub struct Cube {
     /// The rectangle faces of the cube

--- a/src/tracer/object/cube/cube_tests.rs
+++ b/src/tracer/object/cube/cube_tests.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+#[test]
+fn does_intersect() {
+    let cube = Cube::new(Material::Mirror);
+    let r = Ray::new(10.0 * DVec3::ONE, DVec3::NEG_ONE);
+
+    assert!(cube.hit(&r, 0.0, INFINITY).is_some());
+}
+
+#[test]
+fn no_intersect_behind() {
+    let cube = Cube::new(Material::Mirror);
+    let r = Ray::new(10.0 * DVec3::ONE, DVec3::ONE);
+
+    assert!(cube.hit(&r, 0.0, INFINITY).is_none());
+}

--- a/src/tracer/object/disk.rs
+++ b/src/tracer/object/disk.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(test)]
+mod disk_tests;
+
 /// A two dimensional disk
 pub struct Disk {
     /// Origin of the disk

--- a/src/tracer/object/disk.rs
+++ b/src/tracer/object/disk.rs
@@ -71,10 +71,9 @@ impl Sampleable for Disk {
             ))
     }
 
-    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> Ray {
+    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> DVec3 {
         let xi = self.sample_on(rand_sq);
-        let wi = xi - xo;
-        Ray::new(xo, wi)
+        xi - xo
     }
 
     fn sample_towards_pdf(&self, ri: &Ray) -> (f64, Option<Hit>) {

--- a/src/tracer/object/disk/disk_tests.rs
+++ b/src/tracer/object/disk/disk_tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+const NUM_RAYS: usize = 10000;
+
+fn unit_disk() -> Box<Disk> {
+    Disk::new(DVec3::ZERO, DVec3::Z, 1.0, Material::Mirror)
+}
+
+#[test]
+fn does_intersect() {
+    let d = unit_disk();
+    let r = Ray::new(3.0 * DVec3::ONE, DVec3::NEG_ONE);
+
+    assert!(d.hit(&r, 0.0, INFINITY).is_some());
+}
+
+#[test]
+fn no_intersect_behind() {
+    let d = unit_disk();
+    let r = Ray::new(2.0 * DVec3::ONE, DVec3::ONE);
+
+    assert!(d.hit(&r, 0.0, INFINITY).is_none());
+}
+
+#[test]
+fn sampled_rays_hit() {
+    let d = unit_disk();
+
+    let xo = 5.0 * DVec3::ONE;
+
+    for _ in 0..NUM_RAYS {
+        let wi = d.sample_towards(xo, rand_utils::unit_square());
+        let ri = Ray::new(xo, wi);
+        let (p, _) = d.sample_towards_pdf(&ri);
+
+        assert!(p > 0.0);
+    }
+}

--- a/src/tracer/object/instance.rs
+++ b/src/tracer/object/instance.rs
@@ -97,14 +97,11 @@ impl<T: Sampleable> Sampleable for Instance<T> {
         self.transform.transform_point3(sample_local)
     }
 
-    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> Ray {
+    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> DVec3 {
         let xo_local = self.inv_transform.transform_point3(xo);
-        let sample_local = self.object.sample_towards(xo_local, rand_sq);
+        let dir_local = self.object.sample_towards(xo_local, rand_sq);
 
-        Ray::new(
-            xo,
-            self.transform.transform_vector3(sample_local.dir)
-        )
+        self.transform.transform_vector3(dir_local)
     }
 
     fn sample_towards_pdf(&self, ri: &Ray) -> (f64, Option<Hit>) {

--- a/src/tracer/object/instance.rs
+++ b/src/tracer/object/instance.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(test)]
+mod instance_tests;
+
 /// Instance of an object i.e. an object to which affine transformations have
 /// been applied
 pub struct Instance<T> {

--- a/src/tracer/object/instance/instance_tests.rs
+++ b/src/tracer/object/instance/instance_tests.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+const NUM_SAMPLES: usize = 10000;
+
+#[test]
+fn sampling_equals_plain_object() {
+    let ref_sphere = Sphere::new(DVec3::Z, 1.0, Material::Blank);
+    let sphere = Sphere::new(DVec3::ZERO, 0.1, Material::Blank)
+        .rotate_x(PI)
+        .scale(10.0, 10.0, 10.0)
+        .rotate_y(PI)
+        .rotate_z(PI)
+        .translate(0.0, 0.0, 1.0);
+
+    let xo = DVec3::NEG_Z;
+
+    for _ in 0..NUM_SAMPLES {
+        let wi = sphere.sample_towards(xo, rand_utils::unit_square());
+        let ri = Ray::new(xo, wi);
+        let (ref_p, _) = ref_sphere.sample_towards_pdf(&ri);
+        let (p, _) = sphere.sample_towards_pdf(&ri);
+
+        assert!((ref_p - p).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn sampled_direction_hits() {
+    let sphere = Sphere::new(DVec3::ZERO, 0.1, Material::Blank)
+        .translate(0.123, 0.456, 0.789)
+        .scale(2.0, 2.0, 2.0)
+        .rotate_x(PI);
+
+
+    let xo = DVec3::NEG_Z;
+
+    for _ in 0..NUM_SAMPLES {
+        let wi = sphere.sample_towards(xo, rand_utils::unit_square());
+        let ri = Ray::new(xo, wi);
+        let (p, _) = sphere.sample_towards_pdf(&ri);
+
+        assert!(p > 0.0);
+    }
+}

--- a/src/tracer/object/plane/plane_tests.rs
+++ b/src/tracer/object/plane/plane_tests.rs
@@ -1,24 +1,24 @@
 use super::*;
 
 fn plane() -> Box<Plane> {
-    Plane::new(DVec3::ZERO, DVec3::ONE, Material::Blank)
+    Plane::new(DVec3::ZERO, DVec3::Z, Material::Blank)
 }
 
 #[test]
 fn no_self_intersect() {
-    let r = Ray::new(DVec3::ZERO, DVec3::ONE);
+    let r = Ray::new(DVec3::ZERO, DVec3::Z);
     assert!(plane().hit(&r, 0.0, INFINITY).is_none());
 }
 
 #[test]
 fn no_intersect_behind() {
-    let r = Ray::new(DVec3::ONE, DVec3::ONE);
+    let r = Ray::new(DVec3::ONE, DVec3::Z);
     assert!(plane().hit(&r, 0.0, INFINITY).is_none());
 }
 
 #[test]
 fn intersects() {
-    let r = Ray::new(-DVec3::ONE, DVec3::ONE);
+    let r = Ray::new(DVec3::NEG_ONE, DVec3::Z);
     assert!(plane().hit(&r, 0.0, INFINITY).is_some());
 }
 
@@ -26,9 +26,8 @@ fn intersects() {
 fn no_hit_crash_parallel() {
     let p = plane();
     let r = Ray::new(
-        -DVec3::ONE,
-        // pray it works
-        p.norm.cross(DVec3::new(1.23, 4.56, 7.89)),
+        DVec3::NEG_ONE,
+        DVec3::X,
     );
     assert!(p.hit(&r, 0.0, INFINITY).is_none());
 }

--- a/src/tracer/object/rectangle.rs
+++ b/src/tracer/object/rectangle.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(test)]
+mod rectangle_tests;
+
 /// Given a triangle, with points read from the columns of the matrix `abc`,
 /// returns `b` mirrored to define a rectangle.
 fn _triangle_to_rect(abc: DMat3) -> DVec3 {

--- a/src/tracer/object/rectangle.rs
+++ b/src/tracer/object/rectangle.rs
@@ -63,7 +63,7 @@ impl Object for Rectangle {
 
 impl Sampleable for Rectangle {
 
-    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> Ray {
+    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> DVec3 {
         self.choose_triangle().sample_towards(xo, rand_sq)
     }
 

--- a/src/tracer/object/rectangle/rectangle_tests.rs
+++ b/src/tracer/object/rectangle/rectangle_tests.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+fn xy_rect() -> Box<Rectangle> {
+    Rectangle::new(
+        DMat3::from_cols(
+            DVec3::Z,
+            DVec3::Z + DVec3::X,
+            DVec3::ONE
+        ),
+        Material::Mirror,
+    )
+}
+
+#[test]
+fn does_intersect() {
+    let rect = xy_rect();
+    let r = Ray::new(DVec3::ZERO, DVec3::Z);
+
+    assert!(rect.hit(&r, 0.0, INFINITY).is_some());
+}
+
+#[test]
+fn no_hit_behind() {
+    let rect = xy_rect();
+    let r = Ray::new(DVec3::ZERO, DVec3::NEG_Z);
+
+    assert!(rect.hit(&r, 0.0, INFINITY).is_none());
+}

--- a/src/tracer/object/rectangle/rectangle_tests.rs
+++ b/src/tracer/object/rectangle/rectangle_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const NUM_RAYS: usize = 10000;
+
 fn xy_rect() -> Box<Rectangle> {
     Rectangle::new(
         DMat3::from_cols(
@@ -25,4 +27,18 @@ fn no_hit_behind() {
     let r = Ray::new(DVec3::ZERO, DVec3::NEG_Z);
 
     assert!(rect.hit(&r, 0.0, INFINITY).is_none());
+}
+
+#[test]
+fn sampled_rays_hit() {
+    let rect = xy_rect();
+    let xo = 5.0 * DVec3::Z;
+
+    for _ in 0..NUM_RAYS {
+        let wi = rect.sample_towards(xo, rand_utils::unit_square());
+        let ri = Ray::new(xo, wi);
+        let (p, _) = rect.sample_towards_pdf(&ri);
+
+        assert!(p > 0.0);
+    }
 }

--- a/src/tracer/object/sphere.rs
+++ b/src/tracer/object/sphere.rs
@@ -45,11 +45,10 @@ impl Object for Sphere {
     fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<Hit> {
         let xo = r.origin;
         let from_origin = xo - self.origin;
-        // coefficients of "hit quadratic"
-        // .dot faster than .length_squared, recheck
-        let a = r.dir.dot(r.dir);
+
+        let a = r.dir.length_squared();
         let half_b = from_origin.dot(r.dir);
-        let c = from_origin.dot(from_origin) - self.radius * self.radius;
+        let c = from_origin.length_squared() - self.radius * self.radius;
         let disc = half_b * half_b - a * c;
 
         if disc < 0.0 {

--- a/src/tracer/object/sphere.rs
+++ b/src/tracer/object/sphere.rs
@@ -83,7 +83,7 @@ impl Sampleable for Sphere {
     /// Visible area from `xo` forms a cone. Sample a random point on the
     /// spherical cap that the visible area forms. Return a ray with direction
     /// towards the sampled point. TODO: `xo` inside sphere
-    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> Ray {
+    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> DVec3 {
         /* uvw-orthonormal basis,
          * where w is the direction from xo to origin of this sphere. */
         let uvw = Onb::new(self.origin - xo);
@@ -128,9 +128,7 @@ impl Sampleable for Sphere {
 
         let xi = self.origin + ng * self.radius;
 
-        let wi = xi - xo;
-
-        Ray::new(xo, wi)
+        xi - xo
     }
     /* make sphere pdf, area pdf, etc..? */
     /// PDF (w.r.t area) for sampling area of the sphere

--- a/src/tracer/object/sphere.rs
+++ b/src/tracer/object/sphere.rs
@@ -45,10 +45,11 @@ impl Object for Sphere {
     fn hit(&self, r: &Ray, t_min: f64, t_max: f64) -> Option<Hit> {
         let xo = r.origin;
         let from_origin = xo - self.origin;
+        let radius2 = self.radius * self.radius;
 
         let a = r.dir.length_squared();
         let half_b = from_origin.dot(r.dir);
-        let c = from_origin.length_squared() - self.radius * self.radius;
+        let c = from_origin.length_squared() - radius2;
         let disc = half_b * half_b - a * c;
 
         if disc < 0.0 {
@@ -64,6 +65,7 @@ impl Object for Sphere {
         }
 
         let xi = r.at(t);
+        let xi = xi * radius2 / xi.distance_squared(self.origin);
         let ni = (xi - self.origin) / self.radius;
 
         Hit::new(t, self, xi, ni, ni)

--- a/src/tracer/object/sphere/sphere_tests.rs
+++ b/src/tracer/object/sphere/sphere_tests.rs
@@ -1,7 +1,24 @@
 use super::*;
 
+const NUM_RAYS: usize = 10000;
+
 fn unit_sphere() -> Box<Sphere> {
     Sphere::new(DVec3::ZERO, 1.0, Material::Blank)
+}
+
+#[test]
+fn sampled_rays_hit() {
+    let s = unit_sphere();
+
+    let xo = 5.0 * DVec3::Z;
+
+    for _ in 0..NUM_RAYS {
+        let wi = s.sample_towards(xo, rand_utils::unit_square());
+        let ri = Ray::new(xo, wi);
+        let (p, _) = s.sample_towards_pdf(&ri);
+
+        assert!(p > 0.0);
+    }
 }
 
 #[test]

--- a/src/tracer/object/triangle.rs
+++ b/src/tracer/object/triangle.rs
@@ -142,10 +142,9 @@ impl Sampleable for Triangle {
     }
 
     /// Choose random point on surface of triangle. Shoot ray towards it.
-    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> Ray {
+    fn sample_towards(&self, xo: DVec3, rand_sq: DVec2) -> DVec3 {
         let xi = self.sample_on(rand_sq);
-        let wi = xi - xo;
-        Ray::new(xo, wi)
+        xi - xo
     }
 
     fn sample_towards_pdf(&self, ri: &Ray) -> (f64, Option<Hit>) {

--- a/src/tracer/object/triangle/triangle_tests.rs
+++ b/src/tracer/object/triangle/triangle_tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::tracer::texture::Texture;
 
+const NUM_RAYS: usize = 10000;
+
 fn get_mat() -> Material {
     Material::diffuse(Texture::Solid(DVec3::ONE))
 }
@@ -40,4 +42,25 @@ fn no_self_intersect() {
     );
     let r = Ray::new(DVec3::ZERO, DVec3::new(0.0, 0.0, -1.0));
     assert!(t.hit(&r, 0.0, INFINITY).is_none());
+}
+
+#[test]
+fn sampled_rays_hit() {
+    let tri = Triangle::new(
+        (
+            DVec3::ZERO,
+            DVec3::X,
+            DVec3::X + DVec3::Y,
+        ),
+        get_mat(),
+    );
+    let xo = 5.0 * DVec3::Z;
+
+    for _ in 0..NUM_RAYS {
+        let wi = tri.sample_towards(xo, rand_utils::unit_square());
+        let ri = Ray::new(xo, wi);
+        let (p, _) = tri.sample_towards_pdf(&ri);
+
+        assert!(p > 0.0);
+    }
 }

--- a/src/tracer/onb.rs
+++ b/src/tracer/onb.rs
@@ -41,3 +41,19 @@ impl Onb {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_directions() {
+        let w = DVec3::new(1.23, 4.56, 7.89);
+        let uvw = Onb::new(w);
+
+        let v = DVec3::new(9.87, 6.54, 3.21);
+        let vp = uvw.to_world(uvw.to_local(v));
+
+        assert!(v.distance(vp) < 1e-10);
+    }
+}

--- a/src/tracer/pdfs.rs
+++ b/src/tracer/pdfs.rs
@@ -8,6 +8,9 @@ use crate::EPSILON;
 use glam::{DVec2, DVec3};
 use std::f64::consts::PI;
 
+#[cfg(test)]
+mod pdf_tests;
+
 /// Assumes that each generation and evaluation has same starting point.
 pub trait Pdf {
     /// Generates a random direction according to the sampling strategy

--- a/src/tracer/pdfs/pdf_tests.rs
+++ b/src/tracer/pdfs/pdf_tests.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+#[test]
+fn reject_bad_mfd_samples() {
+    let pdf = MfdPdf::new(
+        DVec3::Z,
+        DVec3::Z,
+        DVec3::ONE,
+        MfDistribution::diffuse(),
+    );
+
+    // cos hemisphere sampling
+    assert!(pdf.sample_cos_hemisphere_pdf(DVec3::Y) == 0.0);
+
+    // bad internal reflection
+    assert!(pdf.sample_ndf_refract_pdf(DVec3::Z) == 0.0);
+
+    // bad refraction
+    assert!(pdf.sample_ndf_refract_pdf(DVec3::Y) == 0.0);
+}

--- a/src/tracer/pdfs/pdf_tests.rs
+++ b/src/tracer/pdfs/pdf_tests.rs
@@ -1,20 +1,39 @@
 use super::*;
 
-#[test]
-fn reject_bad_mfd_samples() {
-    let pdf = MfdPdf::new(
+fn mfd_pdf() -> MfdPdf {
+    MfdPdf::new(
         DVec3::Z,
         DVec3::Z,
         DVec3::ONE,
-        MfDistribution::diffuse(),
-    );
+        MfDistribution::specular(1.0),
+    )
+}
 
+#[test]
+fn reject_bad_mfd_hemisphere() {
+    let pdf = mfd_pdf();
     // cos hemisphere sampling
     assert!(pdf.sample_cos_hemisphere_pdf(DVec3::Y) == 0.0);
+}
+
+#[test]
+fn reject_bad_mfd_refracts() {
+    let pdf = mfd_pdf();
 
     // bad internal reflection
     assert!(pdf.sample_ndf_refract_pdf(DVec3::Z) == 0.0);
 
     // bad refraction
     assert!(pdf.sample_ndf_refract_pdf(DVec3::Y) == 0.0);
+}
+
+#[test]
+fn delta_value_for() {
+    let pdf = DeltaPdf::new(DVec3::Z);
+
+    let r = Ray::new(DVec3::ZERO, DVec3::Z + 1e-5 * DVec3::X);
+    assert!(pdf.value_for(&r) == 1.0);
+
+    let r = Ray::new(DVec3::ZERO, DVec3::NEG_Z);
+    assert!(pdf.value_for(&r) == 0.0);
 }

--- a/src/tracer/pdfs/pdf_tests.rs
+++ b/src/tracer/pdfs/pdf_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::tracer::object::Sphere;
+use crate::tracer::material::Material;
 
 fn mfd_pdf() -> MfdPdf {
     MfdPdf::new(
@@ -36,4 +38,22 @@ fn delta_value_for() {
 
     let r = Ray::new(DVec3::ZERO, DVec3::NEG_Z);
     assert!(pdf.value_for(&r) == 0.0);
+}
+
+#[test]
+fn object_pdf_returns_solid_angle() {
+    let sphere = Sphere::new(DVec3::ZERO, 1.0, Material::Blank);
+    let xo = 3.0 * DVec3::Z;
+    let wi = DVec3::NEG_Z;
+    let ri = Ray::new(xo, wi);
+    let (pa, hi) = sphere.sample_towards_pdf(&ri);
+    assert!(hi.is_some());
+
+    let hi = hi.unwrap();
+    let pa = pa * xo.distance_squared(hi.p) / hi.ng.dot(wi).abs();
+
+    let pdf = ObjectPdf::new(&*sphere, xo);
+    let psa = pdf.value_for(&ri);
+
+    assert!((pa - psa).abs() < 1e-15);
 }

--- a/src/tracer/ray.rs
+++ b/src/tracer/ray.rs
@@ -1,5 +1,5 @@
 use glam::{DAffine3, DVec3};
-use crate::{Axis, EPSILON_RAY_OFFSET};
+use crate::Axis;
 
 /// Ray abstraction
 pub struct Ray {
@@ -29,7 +29,7 @@ impl Ray {
 
     /// Position of the ray at time `t`
     pub fn at(&self, t: f64) -> DVec3 {
-        self.origin + (t - EPSILON_RAY_OFFSET) * self.dir
+        self.origin + t * self.dir
     }
 
     /// Coordinate of origin along axis

--- a/src/tracer/ray.rs
+++ b/src/tracer/ray.rs
@@ -1,5 +1,5 @@
 use glam::{DAffine3, DVec3};
-use crate::Axis;
+use crate::{Axis, EPSILON_RAY_OFFSET};
 
 /// Ray abstraction
 pub struct Ray {
@@ -29,7 +29,7 @@ impl Ray {
 
     /// Position of the ray at time `t`
     pub fn at(&self, t: f64) -> DVec3 {
-        self.origin + t * self.dir
+        self.origin + (t - EPSILON_RAY_OFFSET) * self.dir
     }
 
     /// Coordinate of origin along axis


### PR DESCRIPTION
* Add `f64` with error propagation due to floating point inaccuracies
* Improve test coverage
* Avoid self intersection at low grazing angles by moving ray origins by `EPSILON` of normal

Closes #11 
Closes #17 